### PR TITLE
fix: two host match bugs is fixed

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -13,7 +13,6 @@ local ffi_cast    = ffi.cast
 local ffi_cdef    = ffi.cdef
 local insert_tab  = table.insert
 local string      = string
-local str_len     = string.len
 local io          = io
 local package     = package
 local getmetatable=getmetatable
@@ -167,8 +166,7 @@ local function insert_route_with_host(self, opts)
     local path = opts.path
     opts = clone_tab(opts)
 
-    if not self.disable_path_cache_opt
-       and opts.path_op == '=' then
+    if not self.disable_path_cache_opt and opts.path_op == '=' then
 
         if not self.hash_path_with_host[path] then
             self.hash_path_with_host[path] = {opts}
@@ -325,7 +323,7 @@ function pre_insert_route(self, path, route)
     end
 
 
-    if route_opts.hosts and #route_opts.hosts>0 then
+    if route_opts.hosts and #route_opts.hosts > 0 then
         insert_route_with_host(self, route_opts)
     else
         insert_route(self, route_opts)
@@ -374,7 +372,7 @@ function _M.new(routes)
         local hosts_len = 0
         if hosts and #hosts>0 then
             for _,host_item in ipairs(hosts) do
-                local host_len = str_len(host_item)
+                local host_len = #host_item
                 if host_len > hosts_len then
                     hosts_len = host_len
                 end
@@ -383,7 +381,7 @@ function _M.new(routes)
         return hosts_len
     end
 
-    table.sort(routes,function(a,b)
+    table.sort(routes, function(a,b)
           return _get_hosts_max_item_length(a.hosts) > _get_hosts_max_item_length(b.hosts)
     end)
 
@@ -642,9 +640,7 @@ local function match_route_with_host(self, path, opts)
             break
         end
 
-        routes = self.match_data_with_host[idx]
-
- 
+        routes = self.match_data_with_host[idx] 
         if routes then
             local route = _match_from_routes(routes, path, opts)
             if route then
@@ -658,7 +654,6 @@ end
 
 
 local function match_route(self, path, opts)
-
     if opts.host then
         local res   =   match_route_with_host(self, path, opts)
         if res then

--- a/t/host.t
+++ b/t/host.t
@@ -122,3 +122,47 @@ metadata /aa
 nil
 metadata /aa
 nil
+
+
+
+=== TEST 5: mutiple domain (wildcard domain)
+--- config
+    location /t {
+        content_by_lua_block {
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/aa/bb*"},
+                    metadata = "metadata /aa1",
+                    hosts = {"*.bar.com"}
+                },
+                {
+                    paths = {"/aa/bb*"},
+                    metadata = "metadata /aa2",
+                    hosts = {"*.foo.bar.com"}
+                },
+                {
+                    paths = {"/aa*"},
+                    metadata = "metadata /aa3",
+                },
+                {
+                    paths = {"/aa/bb*"},
+                    metadata = "metadata /aa4",
+                    hosts = {"*.bar.com"}
+                }
+            })
+            ngx.say(rx:match("/aa/bb", {host = "qqq.foo.bar.com"}))
+            ngx.say(rx:match("/aa/bb/1", {host = "1.bar.com"}))
+            ngx.say(rx:match("/aa/bb", {host = "bar.com"}))
+            ngx.say(rx:match("/aa/bb/2", {host = "qqq.foo.bar.com"}))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+metadata /aa2
+metadata /aa1
+metadata /aa3
+metadata /aa2


### PR DESCRIPTION
first fixed bug: when set multiple route,it should match the route with host first , when request with host,it will not match the route with host ,event if the uri matchs.

seconed fixed bug: when set two routes ,one with host "*.foo.bar.com",another one is "*.bar.com" ,and the uri is the same ,when request with  "qqq.foo.bar.com"  it match the first route, it should ignore the order of item when creating a radixtree module

fix: https://github.com/iresty/lua-resty-radixtree/issues/26
fix: https://github.com/iresty/lua-resty-radixtree/issues/25


also I think it fixed:
fix: https://github.com/apache/incubator-apisix/issues/761
fix: https://github.com/apache/incubator-apisix/issues/760