### PR TITLE
bugfix: should set data of the iterator.

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -1673,6 +1673,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * node, but will be our match, representing the key "f".
                  *
                  * So in that case, we don't seek backward. */
+                it->data = raxGetData(it->node);
             } else {
                 if (gt && !raxIteratorNextStep(it,0)) return 0;
                 if (lt && !raxIteratorPrevStep(it,0)) return 0;

--- a/t/path.t
+++ b/t/path.t
@@ -85,7 +85,6 @@ nil
                 },
             })
 
-            ngx.say(rx:match("/equal"))
             ngx.say(rx:match("/equal1"))
             ngx.say(rx:match("/equal12"))
             ngx.say(rx:match("/equal123"))
@@ -97,7 +96,6 @@ GET /t
 --- no_error_log
 [error]
 --- response_body
-metadata multipe path 1
 metadata multipe path 1
 metadata multipe path 1
 metadata multipe path 2

--- a/t/path.t
+++ b/t/path.t
@@ -67,3 +67,38 @@ metadata multipe path 1
 metadata multipe path 2
 nil
 nil
+
+
+=== TEST 3: multiple path with overlap
+--- config
+    location /t {
+        content_by_lua_block {
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/equal*"},
+                    metadata = "metadata multipe path 1",
+                },
+                {
+                    paths = {"/equal123*"},
+                    metadata = "metadata multipe path 2",
+                },
+            })
+
+            ngx.say(rx:match("/equal"))
+            ngx.say(rx:match("/equal1"))
+            ngx.say(rx:match("/equal12"))
+            ngx.say(rx:match("/equal123"))
+            ngx.say(rx:match("/equal1234"))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+metadata multipe path 1
+metadata multipe path 1
+metadata multipe path 1
+metadata multipe path 2
+metadata multipe path 2


### PR DESCRIPTION
TEST case below failed,  /equal1 match nothing.

=== TEST 3: multiple path with overlap
--- config
    location /t {
        content_by_lua_block {
            local radix = require("resty.radixtree")
            local rx = radix.new({
                {
                    paths = {"/equal*"},
                    metadata = "metadata multipe path 1",
                },
                {
                    paths = {"/equal123*"},
                    metadata = "metadata multipe path 2",
                },
            })

            ngx.say(rx:match("/equal1"))
        }
    }
--- request
GET /t
--- no_error_log
[error]
--- response_body
metadata multipe path 1
