### PR TITLE
test: add test case for slash path parameter

### DIFF
--- a/t/parameter.t
+++ b/t/parameter.t
@@ -476,7 +476,7 @@ match meta: medium
 
 
 
-=== TEST 14: special characters in parameter should match
+=== TEST 14: special characters in parameter should match (space)
 --- config
     location /t {
         content_by_lua_block {
@@ -501,4 +501,33 @@ GET /t
 [error]
 --- response_body
 match meta: metadata /name
-matched: {"_path":"/name/:name/id","name":"json%20space"}
+matched: {"_path":"/name/:name/id","name":"json%2fspace"}
+
+
+
+=== TEST 15: special characters in parameter should match (slash)
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/name/:name/id"},
+                    metadata = "metadata /name",
+                },
+            })
+
+            local opts = {matched = {}}
+            local meta = rx:match("/name/json%2fslash/id", opts)
+            ngx.say("match meta: ", meta)
+            ngx.say("matched: ", json.encode(opts.matched))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+match meta: metadata /name
+matched: {"_path":"/name/:name/id","name":"json%2fslash"}

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -501,7 +501,7 @@ GET /t
 [error]
 --- response_body
 match meta: metadata /name
-matched: {"_path":"/name/:name/id","name":"json%2fspace"}
+matched: {"_path":"/name/:name/id","name":"json%20space"}
 
 
 


### PR DESCRIPTION
This demonstrates the correctness of the fix introduced in v2.9.2 ([fix: allow special characters to be matched in uri params](https://github.com/api7/lua-resty-radixtree/commit/c02b4e47ed8417c952913deb7027a6c0ff516059)).

As a consequence:

- it should close api7/lua-resty-radixtree#148, since it demonstrates that the issue is **not related to this library**;
- is related to apache/apisix#11810;